### PR TITLE
Trainings membership check

### DIFF
--- a/src/components/Admin/Members/MemberDashboard.tsx
+++ b/src/components/Admin/Members/MemberDashboard.tsx
@@ -328,7 +328,7 @@ class MemberDashboard extends Component<MemberDashboardProps, MemberDashboardSta
                                     </div>
                                     {this.longTable ?
                                     <div className="memberDashboardGlobalConfigOptionsContainer memberDashboardHideSmallScreen">
-                                        Signup Sem:
+                                        Joining Semester:
                                         <div className="signupSemChangeContainer">
                                             {this.state.loadingSignupSem ? 
                                             <Spin/>

--- a/src/components/Admin/Trainings/CreateTraining.tsx
+++ b/src/components/Admin/Trainings/CreateTraining.tsx
@@ -25,6 +25,7 @@ interface CreateTrainingState {
     currentSignupMaxSessions: number
     currentTrainingId: string
     loadingTraining: boolean
+    semester: string
 }
 
 const DEFAULT_TRAINING_LIMIT = 30
@@ -53,7 +54,8 @@ class CreateTraining extends Component<CreateTrainingProps, CreateTrainingState>
             currentPopulateWeekValue: 1,
             currentSignupMaxSessions: 1,
             currentTrainingId: '',
-            loadingTraining: false
+            loadingTraining: false,
+            semester: '',
         }
     }
     populateWeeklyDefaults = () => {
@@ -107,7 +109,8 @@ class CreateTraining extends Component<CreateTrainingProps, CreateTrainingState>
                         currentFeedback: training.feedback,
                         currentTrainingId: training.trainingId,
                         currentSignupMaxSessions: training.signupMaxSessions,
-                        loadingTraining: false
+                        loadingTraining: false,
+                        semester: training.semester
                     })
                 })
                 .catch((err) => {
@@ -224,6 +227,13 @@ class CreateTraining extends Component<CreateTrainingProps, CreateTrainingState>
             currentSessions: this.state.currentSessions.concat([newSession])
         })
     }
+    onSemesterChange = (semester: string) => {
+        console.log('semester change', semester);
+        this.setState({
+            ...this.state,
+            semester: semester
+        })
+    }
     onSubmitForm = () => {
         if (!this.state.currentTitle) {
             notification.error({
@@ -235,6 +245,11 @@ class CreateTraining extends Component<CreateTrainingProps, CreateTrainingState>
             return
         } else if (this.state.currentSessions.find(s => !s.title)) {
             notification.error({message: 'All session options must have a title'})
+            return
+        } else if (this.state.semester === '') {
+            notification.error({
+                message: 'Semester selection required'
+            })
             return
         }
         this.setState({
@@ -254,7 +269,8 @@ class CreateTraining extends Component<CreateTrainingProps, CreateTrainingState>
             openToPublic: this.state.currentOpenToPublic,
             notes: this.state.currentNotes,
             trainingId: this.state.currentTrainingId || this.state.currentTitle.split(' ').join('').slice(0, 13) + this.generateSessionId(7),
-            feedback: this.state.currentFeedback
+            feedback: this.state.currentFeedback,
+            semester: this.state.semester
         })
         .then(() => {
             this.setState({
@@ -318,6 +334,14 @@ class CreateTraining extends Component<CreateTrainingProps, CreateTrainingState>
                         )
                     })}
                 </div>
+
+                <h4 className='formSectionTitle'>Semester</h4>
+                <Radio.Group buttonStyle="solid" name="semesterRadio" onChange={e => this.onSemesterChange(e.target.value)}>
+                    <Radio.Button value={'S1'}>Semester 1</Radio.Button>
+                    <Radio.Button value={'S2'}>Semester 2</Radio.Button>
+                    <Radio.Button value={'SS'}>Summer School</Radio.Button>
+                </Radio.Group>
+
                 <h4 className='formSectionTitle'>Notes</h4>
                 <div className="notesContainer">
                     <MarkdownEditor

--- a/src/components/Admin/Trainings/CreateTraining.tsx
+++ b/src/components/Admin/Trainings/CreateTraining.tsx
@@ -336,7 +336,7 @@ class CreateTraining extends Component<CreateTrainingProps, CreateTrainingState>
                 </div>
 
                 <h4 className='formSectionTitle'>Semester</h4>
-                <Radio.Group buttonStyle="solid" name="semesterRadio" onChange={e => this.onSemesterChange(e.target.value)}>
+                <Radio.Group buttonStyle="solid" name="semesterRadio" value={this.state.semester} onChange={e => this.onSemesterChange(e.target.value)}>
                     <Radio.Button value={'S1'}>Semester 1</Radio.Button>
                     <Radio.Button value={'S2'}>Semester 2</Radio.Button>
                     <Radio.Button value={'SS'}>Summer School</Radio.Button>

--- a/src/components/Content/info/Merch.tsx
+++ b/src/components/Content/info/Merch.tsx
@@ -1,5 +1,4 @@
 import React, {Component} from 'react'
-import {Divider} from 'antd'
 import './Merch.css'
 
 export class Merch extends Component {

--- a/src/components/Content/join/MainJoin.tsx
+++ b/src/components/Content/join/MainJoin.tsx
@@ -69,15 +69,28 @@ export class MainJoin extends Component<MainJoinProps, MainJoinState> {
             return <Spin/>
         } else if (this.props.authedUser) {
             return (
-                <Result
-                    className='joinResult'
-                    status='success'
-                    title='You are a member of AUMT!'
-                    subTitle={(this.props.authedUser.paid === 'Yes' ? 
-                    'Our records show your membership covers the current semester.': '') + 
-                    ' Keep an eye out for announcements and next steps by email, Instagram and Facebook!'}
-                    extra={this.getExtraResultContent()}
-                />
+                <div>
+                    <Result
+                        className='joinResult'
+                        status='success'
+                        title='You are a member of AUMT!'
+                        extra={this.getExtraResultContent()}/>
+                    <h1>Your Current Membership</h1>
+                    <p>
+                        Membership coverage: 
+                        <b>
+                            {this.props.authedUser.membership === 'S1' ? ' Semester 1 ': ''}
+                            {this.props.authedUser.membership === 'S2' ? ' Semester 2 ': ''}
+                            {this.props.authedUser.membership === 'SS' ? ' Summer School ': ''}
+                            {this.props.authedUser.membership === 'FY' ? ' Full Year (Semester 1 and 2)': ''}
+                        </b>
+                    </p>
+                    <p>
+                        Status:
+                        <b>{this.props.authedUser.paid === 'Yes' ? ' Paid ': ' Not Paid '}</b>
+                    </p>
+                </div>
+                
             )
         } else if (this.props.clubSignupStatus === 'closed') {
             return (

--- a/src/components/Content/signups/Signups.tsx
+++ b/src/components/Content/signups/Signups.tsx
@@ -112,55 +112,80 @@ class Signups extends Component<SignupProps, SignupState> {
                                         <Divider/>
                                     </div>
                                 )
-                            } else if (this.props.authedUser && this.props.authedUser.paid === 'No') {
-                                return <div key={form.trainingId} className='signupsNotPaidContainer'>
-                                    <h2>{form.title}</h2>
-                                    <p>Our records show you have not paid the membership fee - once you do, you can sign up to trainings!</p>
-                                    <p>
-                                        Membership is 
-                                        {this.props.clubSignupSem === 'S1' ? ' $50 for the semester or $90 for the year ': ''}
-                                        {this.props.clubSignupSem === 'S2' ? ' $50 for the semester ': ''}
-                                        {this.props.clubSignupSem === 'SS' ? ' $30 for summer school ': ''} 
-                                        and includes a training session each week!
+                            } else if (this.props.authedUser && 
+                                this.props.authedUser.paid === 'Yes' && 
+                                (this.props.authedUser.membership === form.semester || 
+                                    (this.props.authedUser.membership === 'FY' && form.semester !== 'SS'))) {
+                                return (
+                                    <div key={form.trainingId} className="formContainer">
+                                        <SignupForm
+                                            title={form.title} 
+                                            id={form.trainingId} 
+                                            closes={form.closes} 
+                                            sessions={form.sessions} 
+                                            displayName={this.getDisplayName()}
+                                            showNotes={true}
+                                            submittingAsName={this.props.authedUser ?
+                                                `${this.props.authedUser.preferredName || this.props.authedUser.firstName} ${this.props.authedUser.lastName}`
+                                                : ''}
+                                            authedUserId={this.props.authedUserId}
+                                            notes={form.notes}
+                                            signupMaxSessions={form.signupMaxSessions}
+                                            openToPublic={form.openToPublic}/>
+                                    </div>
+                                );
+                            } else {
+                                return (
+                                    <div key={form.trainingId} className='signupsNotPaidContainer'>
+                                        <h2>{form.title}</h2>
+                                        <p>Our records show you have not paid the membership fee for this semester - once you do, you can sign up to trainings!</p>
+                                        <p>
+                                            Membership is 
+                                            {this.props.clubSignupSem === 'S1' ? ' $50 for the semester or $90 for the year ': ''}
+                                            {this.props.clubSignupSem === 'S2' ? ' $50 for the semester ': ''}
+                                            {this.props.clubSignupSem === 'SS' ? ' $30 for summer school ': ''} 
+                                            and includes a training session each week!
 
-                                        Please pay membership fees to the account below and add your NAME and 
-                                        {this.props.clubSignupSem === 'S1' ? ` 'AUMTS1' (for one semester) or AUMTFY (for one year) ` : ''}
-                                        {this.props.clubSignupSem === 'S2' ? ` 'AUMTS2' (for one semester) ` : ''}
-                                        {this.props.clubSignupSem === 'SS' ? ` 'AUMTSS' (for summer school) ` : ''}
-                                        as the reference.
-                                    </p>
-                                    <p>06-0158-0932609-00 <Button type='link' onClick={e => this.copyText('06-0158-0932609-00')}>Copy Account Number</Button></p>
-                                    <Divider/>
+                                            Please pay membership fees to the account below and add your NAME and 
+                                            {this.props.clubSignupSem === 'S1' ? ` 'AUMTS1' (for one semester) or AUMTFY (for one year) ` : ''}
+                                            {this.props.clubSignupSem === 'S2' ? ` 'AUMTS2' (for one semester) ` : ''}
+                                            {this.props.clubSignupSem === 'SS' ? ` 'AUMTSS' (for summer school) ` : ''}
+                                            as the reference.
+                                        </p>
+                                        <p>06-0158-0932609-00 <Button type='link' onClick={e => this.copyText('06-0158-0932609-00')}>Copy Account Number</Button></p>
+                                        <Divider/>
 
-                                    <h3>This Week Only</h3>
-                                    <p>
-                                        If you would like to pay at the training, message the AUMT Facebook page - we will sign you up for the session of your choice.
-                                    </p>
-                                    <br/>
-                                    
-                                </div>
+                                        <h3>This Week Only</h3>
+                                        <p>
+                                            If you would like to pay at the training, message the AUMT Facebook page - we will sign you up for the session of your choice.
+                                        </p>
+                                        <br/>
+                                        
+                                    </div>
+                                );
                             }
+                        } else {
+                            return (
+                                <div key={form.trainingId} className="formContainer">
+                                    <SignupForm
+                                        title={form.title} 
+                                        id={form.trainingId} 
+                                        closes={form.closes} 
+                                        sessions={form.sessions} 
+                                        displayName={this.getDisplayName()}
+                                        showNotes={true}
+                                        submittingAsName={this.props.authedUser ?
+                                            `${this.props.authedUser.preferredName || this.props.authedUser.firstName} ${this.props.authedUser.lastName}`
+                                            : ''}
+                                        authedUserId={this.props.authedUserId}
+                                        notes={form.notes}
+                                        signupMaxSessions={form.signupMaxSessions}
+                                        openToPublic={form.openToPublic} />
+                                </div>
+                            )       
                         }
-                        // Can view form
-                        return (
-                            <div key={form.trainingId} className="formContainer">
-                                <SignupForm
-                                    title={form.title} 
-                                    id={form.trainingId} 
-                                    closes={form.closes} 
-                                    sessions={form.sessions} 
-                                    displayName={this.getDisplayName()}
-                                    showNotes={true}
-                                    submittingAsName={this.props.authedUser ?
-                                        `${this.props.authedUser.preferredName || this.props.authedUser.firstName} ${this.props.authedUser.lastName}`
-                                        : ''}
-                                    authedUserId={this.props.authedUserId}
-                                    notes={form.notes}
-                                    signupMaxSessions={form.signupMaxSessions}
-                                    openToPublic={form.openToPublic}/>
-                            </div>
-                        )
-                    })}
+                    })
+                }
             </div>
         )
     }

--- a/src/components/Content/signups/Signups.tsx
+++ b/src/components/Content/signups/Signups.tsx
@@ -100,15 +100,18 @@ class Signups extends Component<SignupProps, SignupState> {
             <div className='signupsContainer'>
                 {this.state.forms
                     .map((form) => {
+                        console.log(form);
                         if (!form.openToPublic) {
                             if (!this.props.authedUserId) {
-                                return <div key={form.trainingId}>
-                                    <h2>{form.title}</h2>
-                                    <p>You must <Link to='/login?from=/signups'> log in </Link> to view and sign up!</p>
-                                    <h4>Not a member?</h4>
-                                    <p><Link to='/join'>Join the club!</Link> Club signups are open at the beginning of each semester.</p>
-                                    <Divider/>
-                                </div>
+                                return (
+                                    <div key={form.trainingId}>
+                                        <h2>{form.title}</h2>
+                                        <p>You must <Link to='/login?from=/signups'> log in </Link> to view and sign up!</p>
+                                        <h4>Not a member?</h4>
+                                        <p><Link to='/join'>Join the club!</Link> Club signups are open at the beginning of each semester.</p>
+                                        <Divider/>
+                                    </div>
+                                )
                             } else if (this.props.authedUser && this.props.authedUser.paid === 'No') {
                                 return <div key={form.trainingId} className='signupsNotPaidContainer'>
                                     <h2>{form.title}</h2>
@@ -154,10 +157,9 @@ class Signups extends Component<SignupProps, SignupState> {
                                     authedUserId={this.props.authedUserId}
                                     notes={form.notes}
                                     signupMaxSessions={form.signupMaxSessions}
-                                    openToPublic={form.openToPublic}
-                                    ></SignupForm>
-                                </div>
-                            )
+                                    openToPublic={form.openToPublic}/>
+                            </div>
+                        )
                     })}
             </div>
         )

--- a/src/components/Content/signups/Signups.tsx
+++ b/src/components/Content/signups/Signups.tsx
@@ -141,15 +141,15 @@ class Signups extends Component<SignupProps, SignupState> {
                                         <p>Our records show you have not paid the membership fee for this semester - once you do, you can sign up to trainings!</p>
                                         <p>
                                             Membership is 
-                                            {this.props.clubSignupSem === 'S1' ? ' $50 for the semester or $90 for the year ': ''}
-                                            {this.props.clubSignupSem === 'S2' ? ' $50 for the semester ': ''}
-                                            {this.props.clubSignupSem === 'SS' ? ' $30 for summer school ': ''} 
+                                            {form.semester === 'S1' ? ' $50 for the semester 1 or $90 for the year ': ''}
+                                            {form.semester === 'S2' ? ' $50 for the semester 2 ': ''}
+                                            {form.semester === 'SS' ? ' $30 for summer school ': ''} 
                                             and includes a training session each week!
 
                                             Please pay membership fees to the account below and add your NAME and 
-                                            {this.props.clubSignupSem === 'S1' ? ` 'AUMTS1' (for one semester) or AUMTFY (for one year) ` : ''}
-                                            {this.props.clubSignupSem === 'S2' ? ` 'AUMTS2' (for one semester) ` : ''}
-                                            {this.props.clubSignupSem === 'SS' ? ` 'AUMTSS' (for summer school) ` : ''}
+                                            {form.semester === 'S1' ? ` 'AUMTS1' (for one semester) or AUMTFY (for one year) ` : ''}
+                                            {form.semester === 'S2' ? ` 'AUMTS2' (for one semester) ` : ''}
+                                            {form.semester === 'SS' ? ` 'AUMTSS' (for summer school) ` : ''}
                                             as the reference.
                                         </p>
                                         <p>06-0158-0932609-00 <Button type='link' onClick={e => this.copyText('06-0158-0932609-00')}>Copy Account Number</Button></p>

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -433,9 +433,11 @@ class DB {
                         const event = this.docToEvent(doc.data())
                         newEvents.push(event)
                     } catch (err) {
-                        if (errorCallback ) {
-                            errorCallback(`Excluding event because ${err.toString()}`)
-                        }
+                        console.warn(err);
+                        // NOTE: uncomment this block if errors occur:
+                        // if (errorCallback ) {
+                        //     errorCallback(`Excluding event because ${err.toString()}`)
+                        // }
                     }
                 })
                 callback(newEvents)

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -502,7 +502,8 @@ class DB {
             openToPublic: docData.openToPublic || false,
             opens: new Date(docData.opens.seconds * 1000),
             closes: new Date(docData.closes.seconds * 1000),
-            notes: docData.notes.split('%%NEWLINE%%').join('\n')
+            notes: docData.notes.split('%%NEWLINE%%').join('\n'),
+            semester: docData.semester,
         }
         return weeklyTraining
     }

--- a/src/types/AumtWeeklyTraining.ts
+++ b/src/types/AumtWeeklyTraining.ts
@@ -27,4 +27,5 @@ export interface AumtWeeklyTraining {
     notes: string
     signupMaxSessions: number
     openToPublic: boolean
+    semester: string
 }


### PR DESCRIPTION
Issue:
A weekly training doesn't block users from signing up if their membership is out of date. 

Solution:
The signup page has safeguards to display only if the weekly training semester property matches the correct user membership type. This semester property must be set when creating a training and can be edited too.

Risks:
Potential branch coverage missing which may lead to faults.

Closes #11 